### PR TITLE
feat: Add Saved Posts screen, fix login crash, and apply brand theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,101 @@
-# Swapi-APP-ANDROID
+# **Swapi**
+
+**A private digital marketplace for university communities.**
+
+Swapi is a digital platform designed for university communities to buy, sell, rent, and offer services in a secure and private environment. The initial deployment is planned for **La Salle University in Chihuahua, Mexico**, but the system is built with scalability in mind.
+
+---
+
+## **About the Project**
+
+Swapi functions as a **private marketplace** exclusive to students and faculty members. Its goal is to create a trusted community where users can interact through verified university accounts.
+
+Users will be able to:
+
+* Post listings for products, rentals, and services.  
+* Search and filter through categories.  
+* Manage their own listings and profiles.
+
+The project includes both a **mobile application (Android)** and a **web platform**, which share a single backend and database.
+
+---
+
+## **Architecture**
+
+Swapi follows a **client-server architecture** divided into three main components. Both clients (web and mobile) communicate with the same backend API via **GraphQL**.
+
+swapi-project/  
+├─ backend/       → Node.js \+ Apollo Server (GraphQL) \+ MongoDB  
+├─ web-frontend/  → React (in development)  
+└─ mobile-app/    → Android (Jetpack Compose \+ MVVM, separate repo)
+
+---
+
+## **Tech Stack**
+
+The development environment consists of:
+
+### **Backend**
+
+* Node.js (v18+)  
+* Apollo Server (GraphQL)  
+* MongoDB (via Mongoose)  
+* JWT Authentication  
+* Express.js  
+* Docker (optional for local MongoDB setup)
+
+### **Frontend (Web)**
+
+* React.js or Next.js (TBD)  
+* Apollo Client for GraphQL  
+* Deployment on Netlify or Vercel
+
+### **Frontend (Mobile)**
+
+* Android Studio  
+* Kotlin \+ Jetpack Compose  
+* MVVM Architecture  
+* Consumes the same GraphQL API
+
+---
+
+## **Getting Started (Backend)**
+
+Follow these steps to get the backend development environment running:
+
+1. Navigate to the backend directory:  
+   Bash  
+   cd backend
+
+2. Install dependencies:  
+   Bash  
+   npm install
+
+3. Create a .env file based on .env.example and fill in your credentials:  
+   Fragmento de código  
+   MONGODB\_URI=your\_mongo\_uri\_here  
+   JWT\_SECRET=your\_secret\_key
+
+4. Start the development server:  
+   Bash  
+   npm run dev
+
+5. You can access the GraphQL playground at:  
+   http://localhost:4000/graphql
+
+---
+
+## **Future Goals**
+
+* Implement user-to-user messaging.  
+* Add file/image uploading for product listings.  
+* Expand to more universities.  
+* Integrate GraphQL subscriptions for real-time updates.  
+* Deploy the backend to Render and the web frontend to Netlify.
+
+---
+
+## **License**
+
+This project is being developed for educational purposes as part of a university software engineering course.  
+All rights reserved to the Swapi development team.

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/components/topbar/SwapiTopBar.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/components/topbar/SwapiTopBar.kt
@@ -57,7 +57,7 @@ fun SwapiTopBar(
                     singleLine = true,
                     textStyle = TextStyle(
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 16.sp
+                        fontSize = 10.sp
                     ),
                     cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/home/productdetail/view/ProductDetailView.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/home/productdetail/view/ProductDetailView.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color // ✨ IMPORTANTE
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -39,11 +40,12 @@ fun ProductDetailView(
     productId: String,
     navController: NavController
 ) {
-    // ViewModel con factory personalizado
+    // ViewModel
     val factory = ProductDetailViewModelFactory(productId, HomeRepository(HomeApiImpl.retrofitApi))
     val viewModel: ProductDetailViewModel = viewModel(factory = factory)
-
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val swapiBrandColor = Color(0xFF4A8BFF)
 
     Scaffold(
         topBar = {
@@ -69,19 +71,27 @@ fun ProductDetailView(
             contentAlignment = Alignment.Center
         ) {
             when (val state = uiState) {
-                is ProductDetailUiState.Loading -> CircularProgressIndicator()
+
+                is ProductDetailUiState.Loading -> CircularProgressIndicator(color = swapiBrandColor)
                 is ProductDetailUiState.Error -> Text(
                     state.message,
                     color = MaterialTheme.colorScheme.error
                 )
-                is ProductDetailUiState.Success -> ProductContentView(product = state.product)
+
+                is ProductDetailUiState.Success -> ProductContentView(
+                    product = state.product,
+                    brandColor = swapiBrandColor
+                )
             }
         }
     }
 }
 
 @Composable
-fun ProductContentView(product: ListingDto) {
+fun ProductContentView(
+    product: ListingDto,
+    brandColor: Color
+) {
     val context = LocalContext.current
     val scrollState = rememberScrollState()
 
@@ -90,7 +100,7 @@ fun ProductContentView(product: ListingDto) {
             .fillMaxSize()
             .verticalScroll(scrollState)
     ) {
-        // Imagen destacada sin overlay
+        // Imagen destacada (sin cambios)
         AsyncImage(
             model = product.imageUrl,
             contentDescription = product.title,
@@ -111,8 +121,10 @@ fun ProductContentView(product: ListingDto) {
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Text(
                     product.title,
-                    style = MaterialTheme.typography.headlineSmall.copy(
-                        fontWeight = FontWeight.Bold
+
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 24.sp // Ajuste fino si es necesario
                     ),
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -121,11 +133,12 @@ fun ProductContentView(product: ListingDto) {
                     style = MaterialTheme.typography.headlineMedium.copy(
                         fontWeight = FontWeight.Bold
                     ),
-                    color = MaterialTheme.colorScheme.primary
+
+                    color = brandColor
                 )
             }
 
-            // Descripción en card
+            // Descripción en card (sin cambios)
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
@@ -149,7 +162,7 @@ fun ProductContentView(product: ListingDto) {
                 }
             }
 
-            // Vendedor en card
+            // Vendedor en card (sin cambios)
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
@@ -194,7 +207,8 @@ fun ProductContentView(product: ListingDto) {
                     .height(56.dp),
                 shape = RoundedCornerShape(14.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary
+                    containerColor = brandColor,
+                    contentColor = Color.White
                 )
             ) {
                 Text(
@@ -206,7 +220,6 @@ fun ProductContentView(product: ListingDto) {
         }
     }
 }
-
 private fun openWhatsApp(context: Context, phoneNumber: String?, productName: String) {
     if (phoneNumber.isNullOrBlank()) {
         Toast.makeText(context, "El vendedor no especificó un número.", Toast.LENGTH_SHORT).show()

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/home/views/HomeView.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/home/views/HomeView.kt
@@ -38,6 +38,7 @@ import com.swapi.swapiV1.home.viewmodel.HomeViewModel
 import com.swapi.swapiV1.home.viewmodel.HomeViewModelFactory
 import com.swapi.swapiV1.navigation.ScreenNavigation
 import com.swapi.swapiV1.utils.datastore.DataStoreManager
+import com.swapi.swapiV1.utils.dismissKeyboardOnClick // ✨ --- ¡IMPORT NUEVO! --- ✨
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -72,7 +73,8 @@ fun HomeView(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding), // Aplicamos el padding de la TopBar
+                .padding(innerPadding) // Aplicamos el padding de la TopBar
+                .dismissKeyboardOnClick(), // ✨ --- ¡MODIFIER APLICADO AQUÍ! --- ✨
             contentAlignment = Alignment.Center
         ) {
             when (val state = uiState) {

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/login/views/SignUpCodeView.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/login/views/SignUpCodeView.kt
@@ -1,0 +1,114 @@
+package com.swapi.swapiV1.login.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.swapi.swapiV1.navigation.ScreenNavigation
+import com.swapi.swapiV1.utils.dismissKeyboardOnClick // ✨ --- ¡IMPORT NUEVO! --- ✨
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignUpCodeView(
+    navHostController: NavHostController,
+    email: String // Recibimos el email de la ruta
+) {
+    var code by remember { mutableStateOf("") }
+    val swapiBrandColor = Color(0xFF4A8BFF)
+    val elegantGradient = Brush.verticalGradient(
+        colors = listOf(
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+            MaterialTheme.colorScheme.background,
+            MaterialTheme.colorScheme.background
+        )
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(elegantGradient)
+            .dismissKeyboardOnClick(), // ✨ --- ¡MODIFIER APLICADO AQUÍ! --- ✨
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .padding(horizontal = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            Text(
+                text = "Ingresa tu código",
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = "Enviamos un código de 6 dígitos a:\n$email",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                ),
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = code,
+                onValueChange = { code = it },
+                label = { Text("Código de 6 dígitos") },
+                singleLine = true,
+                shape = RoundedCornerShape(14.dp),
+                modifier = Modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = swapiBrandColor,
+                    cursorColor = swapiBrandColor,
+                    focusedLabelColor = swapiBrandColor,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                    unfocusedLabelColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            Button(
+                // Solo navega por demo, aquí iría la lógica de verificar el código
+                onClick = {
+                    navHostController.navigate(ScreenNavigation.SignUpProfile.createRoute(email))
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(14.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = swapiBrandColor)
+            ) {
+                Text(
+                    "Verificar",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold, fontSize = 17.sp),
+                    color = Color.White
+                )
+            }
+        }
+
+        // Botón de Volver
+        IconButton(
+            onClick = { navHostController.popBackStack() },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(top = 48.dp, start = 16.dp)
+        ) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Volver", tint = MaterialTheme.colorScheme.onBackground)
+        }
+    }
+}

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/login/views/SignUpEmailView.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/login/views/SignUpEmailView.kt
@@ -1,0 +1,113 @@
+package com.swapi.swapiV1.login.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.swapi.swapiV1.navigation.ScreenNavigation
+import com.swapi.swapiV1.utils.dismissKeyboardOnClick // ✨ --- ¡IMPORT NUEVO! --- ✨
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignUpEmailView(
+    navHostController: NavHostController
+) {
+    var email by remember { mutableStateOf("") }
+    val swapiBrandColor = Color(0xFF4A8BFF)
+    val elegantGradient = Brush.verticalGradient(
+        colors = listOf(
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+            MaterialTheme.colorScheme.background,
+            MaterialTheme.colorScheme.background
+        )
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(elegantGradient)
+            .dismissKeyboardOnClick(), // ✨ --- ¡MODIFIER APLICADO AQUÍ! --- ✨
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .padding(horizontal = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            Text(
+                text = "Verifica tu correo",
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = "Ingresa tu correo institucional para continuar.",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                ),
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text("Correo institucional") },
+                singleLine = true,
+                shape = RoundedCornerShape(14.dp),
+                modifier = Modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = swapiBrandColor,
+                    cursorColor = swapiBrandColor,
+                    focusedLabelColor = swapiBrandColor,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                    unfocusedLabelColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            Button(
+                // Solo navega por demo, pero aquí iría la lógica de enviar el email
+                onClick = {
+                    navHostController.navigate(ScreenNavigation.SignUpCode.createRoute(email.ifBlank { "demo" }))
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(14.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = swapiBrandColor)
+            ) {
+                Text(
+                    "Continuar",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold, fontSize = 17.sp),
+                    color = Color.White
+                )
+            }
+        }
+
+        // Botón de Volver
+        IconButton(
+            onClick = { navHostController.popBackStack() },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(top = 48.dp, start = 16.dp)
+        ) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Volver", tint = MaterialTheme.colorScheme.onBackground)
+        }
+    }
+}

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/login/views/SignUpProfileView.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/login/views/SignUpProfileView.kt
@@ -1,0 +1,203 @@
+package com.swapi.swapiV1.login.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.swapi.swapiV1.navigation.ScreenNavigation
+import com.swapi.swapiV1.utils.dismissKeyboardOnClick // ✨ --- ¡IMPORT NUEVO! --- ✨
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignUpProfileView(
+    navHostController: NavHostController,
+    email: String // Recibimos el email verificado
+) {
+    // --- Lógica de UI (sin cambios) ---
+    var name by remember { mutableStateOf("") }
+    var phone by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var confirmPassword by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var confirmPasswordVisible by remember { mutableStateOf(false) }
+    var isLoading by remember { mutableStateOf(false) }
+
+    // --- Estilo (sin cambios) ---
+    val swapiBrandColor = Color(0xFF4A8BFF)
+    val elegantGradient = Brush.verticalGradient(
+        colors = listOf(
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+            MaterialTheme.colorScheme.background,
+            MaterialTheme.colorScheme.background
+        )
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(elegantGradient)
+            .dismissKeyboardOnClick(), // ✨ --- ¡MODIFIER APLICADO AQUÍ! --- ✨
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 28.dp)
+                .padding(top = 120.dp, bottom = 48.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+
+            Text(
+                text = "Completa tu perfil",
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = "Ya casi terminas. Estás registrando la cuenta:\n$email",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                ),
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // --- CAMPO NOMBRE ---
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Nombre Completo") },
+                singleLine = true,
+                shape = RoundedCornerShape(14.dp),
+                modifier = Modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = swapiBrandColor,
+                    cursorColor = swapiBrandColor,
+                    focusedLabelColor = swapiBrandColor,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                    unfocusedLabelColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            )
+
+            // --- CAMPO CELULAR ---
+            OutlinedTextField(
+                value = phone,
+                onValueChange = { phone = it },
+                label = { Text("Número de celular") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                shape = RoundedCornerShape(14.dp),
+                modifier = Modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = swapiBrandColor,
+                    cursorColor = swapiBrandColor,
+                    focusedLabelColor = swapiBrandColor,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                    unfocusedLabelColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            )
+
+            // --- CAMPO CONTRASEÑA ---
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Contraseña") },
+                singleLine = true,
+                shape = RoundedCornerShape(14.dp),
+                visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = {
+                    val icon = if (passwordVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff
+                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        Icon(icon, "Mostrar", tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f))
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = swapiBrandColor,
+                    cursorColor = swapiBrandColor,
+                    focusedLabelColor = swapiBrandColor,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                    unfocusedLabelColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            )
+
+            // --- CAMPO CONFIRMAR CONTRASEÑA ---
+            OutlinedTextField(
+                value = confirmPassword,
+                onValueChange = { confirmPassword = it },
+                label = { Text("Confirmar contraseña") },
+                singleLine = true,
+                shape = RoundedCornerShape(14.dp),
+                visualTransformation = if (confirmPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = {
+                    val icon = if (confirmPasswordVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff
+                    IconButton(onClick = { confirmPasswordVisible = !confirmPasswordVisible }) {
+                        Icon(icon, "Mostrar", tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f))
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = swapiBrandColor,
+                    cursorColor = swapiBrandColor,
+                    focusedLabelColor = swapiBrandColor,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                    unfocusedLabelColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // --- BOTÓN REGISTRARME ---
+            Button(
+                onClick = {
+                    navHostController.navigate(ScreenNavigation.Login.route) {
+                        popUpTo(ScreenNavigation.Login.route) { inclusive = true }
+                    }
+                },
+                enabled = !isLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(14.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = swapiBrandColor)
+            ) {
+                Text(
+                    "Finalizar Registro",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold, fontSize = 17.sp),
+                    color = Color.White
+                )
+            }
+        }
+
+        // Botón de Volver (sin cambios)
+        IconButton(
+            onClick = { navHostController.popBackStack() },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(top = 48.dp, start = 16.dp)
+        ) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Volver", tint = MaterialTheme.colorScheme.onBackground)
+        }
+    }
+}

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/navigation/ScreenNavigation.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/navigation/ScreenNavigation.kt
@@ -11,9 +11,22 @@ import androidx.compose.ui.graphics.vector.ImageVector
 sealed class ScreenNavigation(val route: String, val label: String, val icon: ImageVector) {
     // --- Main and Auth Screens ---
     object Login : ScreenNavigation("login", "Login", Icons.Default.Person)
+
+    object SignUpEmail : ScreenNavigation("signup_email", "Registro Email", Icons.Default.Email)
+
+    object SignUpCode : ScreenNavigation("signup_code/{email}", "Registro Código", Icons.Default.QrCode) {
+        fun createRoute(email: String) = "signup_code/$email"
+    }
+
+    object SignUpProfile : ScreenNavigation("signup_profile/{email}", "Registro Perfil", Icons.Default.PersonAdd) {
+        fun createRoute(email: String) = "signup_profile/$email"
+    }
+
     object Home : ScreenNavigation("home", "Home", Icons.Default.Home)
     object Profile : ScreenNavigation("profile", "Profile", Icons.Default.AccountCircle)
     object NewPublication : ScreenNavigation("new_publication", "Create", Icons.Default.Add) // <-- Corregido
+
+    object SavedPosts : ScreenNavigation("saved_posts", "Guardados", Icons.Default.Bookmark)
 
     // --- Category Screens (accessed from Home) ---
     object Sales : ScreenNavigation("sales", "Sales", Icons.Default.ShoppingCart) // <-- Corregido

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/navigation/TabBarNavigationView.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/navigation/TabBarNavigationView.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,6 +40,9 @@ import com.swapi.swapiV1.home.views.HomeView
 import com.swapi.swapiV1.profile.view.ProfileView
 import com.swapi.swapiV1.publication.views.NewPublicationView
 import com.swapi.swapiV1.rents.RentsView
+// --- CAMBIO AQUÍ: Import para la nueva pantalla ---
+import com.swapi.swapiV1.saved.views.SavedPostsView
+// --- FIN DEL CAMBIO ---
 import com.swapi.swapiV1.sales.views.SalesView
 import com.swapi.swapiV1.services.ServicesView
 import com.swapi.swapiV1.utils.datastore.DataStoreManager
@@ -64,8 +66,9 @@ fun TabBarNavigationView(
             if (currentRoute in listOf(ScreenNavigation.Home.route, ScreenNavigation.Profile.route)) {
                 Box(modifier = Modifier.fillMaxWidth()) {
                     NavigationBar(
-                        containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
-                        modifier = Modifier.height(80.dp)
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        tonalElevation = 0.dp,
+                        modifier = Modifier.height(72.dp)
                     ) {
                         // Inicio
                         NavigationBarItem(
@@ -114,36 +117,44 @@ fun TabBarNavigationView(
                     Box(
                         modifier = Modifier
                             .align(Alignment.TopCenter)
-                            .offset(y = (-28).dp)
+                            .offset(y = (-48).dp)
                     ) {
                         Box(
                             modifier = Modifier
-                                .size(68.dp)
+                                .size(72.dp)
                                 .shadow(
-                                    elevation = 8.dp,
+                                    elevation = 20.dp,
                                     shape = CircleShape,
-                                    ambientColor = swapiBlue.copy(alpha = 0.3f),
-                                    spotColor = swapiBlue.copy(alpha = 0.3f)
+                                    ambientColor = Color.Black.copy(alpha = 0.6f),
+                                    spotColor = Color.Black.copy(alpha = 0.6f)
                                 )
                                 .clip(CircleShape)
-                                .background(swapiBlue)
-                                .clickable {
-                                    navController.navigate(ScreenNavigation.NewPublication.route)
-                                },
+                                .background(Color.White)
+                                .padding(4.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(
-                                imageVector = Icons.Default.Add,
-                                contentDescription = "Publicar",
-                                tint = Color.White,
-                                modifier = Modifier.size(32.dp)
-                            )
+                            Box(
+                                modifier = Modifier
+                                    .size(64.dp)
+                                    .clip(CircleShape)
+                                    .background(swapiBlue)
+                                    .clickable {
+                                        navController.navigate(ScreenNavigation.NewPublication.route)
+                                    },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Add,
+                                    contentDescription = "Publicar",
+                                    tint = Color.White,
+                                    modifier = Modifier.size(36.dp)
+                                )
+                            }
                         }
                     }
                 }
             }
         },
-        // ✅ Este es el parámetro correcto
         contentWindowInsets = WindowInsets(0.dp)
     ) { innerPadding ->
         NavHost(
@@ -162,6 +173,12 @@ fun TabBarNavigationView(
             composable(ScreenNavigation.Rents.route) { RentsView() }
             composable(ScreenNavigation.Services.route) { ServicesView() }
             composable(ScreenNavigation.Ads.route) { AdsView() }
+
+            // --- CAMBIO AQUÍ: Ruta añadida para "Guardados" ---
+            composable(ScreenNavigation.SavedPosts.route) {
+                SavedPostsView(navController = navController)
+            }
+            // --- FIN DEL CAMBIO ---
 
             composable(
                 route = ScreenNavigation.ProductDetail.route,

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/profile/view/ProfileView.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/profile/view/ProfileView.kt
@@ -29,6 +29,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import coil.compose.rememberAsyncImagePainter
+// --- CAMBIO AQUÍ: Import añadido ---
+import com.swapi.swapiV1.navigation.ScreenNavigation
+// --- FIN DEL CAMBIO ---
 import com.swapi.swapiV1.profile.viewmodel.ProfileUiState
 import com.swapi.swapiV1.profile.viewmodel.ProfileViewModel
 
@@ -44,7 +47,7 @@ data class MenuItem(
 @Composable
 fun ProfileView(
     navController: NavHostController,
-    onLogout: () -> Unit, // <-- CAMBIO: Añadido
+    onLogout: () -> Unit,
     vm: ProfileViewModel = viewModel()
 ) {
     val uiState by vm.uiState.collectAsState()
@@ -85,7 +88,7 @@ fun ProfileView(
                     .padding(paddingValues)
             ) {
                 item { ProfileHeader(uiState) }
-                item { ActionsGrid(navController) }
+                item { ActionsGrid(navController) } // Pasamos el navController
 
                 // Sección "Mi Actividad"
                 item { SectionHeader("Mi Actividad") }
@@ -104,7 +107,6 @@ fun ProfileView(
                     val item = accountItems[index]
                     ProfileListItem(icon = item.icon, title = item.title, subtitle = item.subtitle) {
                         if (item.route == "logout") {
-                            // --- CAMBIO: Se llama a la función ---
                             onLogout()
                         } else {
                             Toast.makeText(context, "Ir a ${item.title}", Toast.LENGTH_SHORT).show()
@@ -130,7 +132,9 @@ private fun ActionsGrid(navController: NavHostController) {
     Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             ActionCard(title = actions[0].first, icon = actions[0].second, modifier = Modifier.weight(1f)) {
-                Toast.makeText(context, "Ir a ${actions[0].first}", Toast.LENGTH_SHORT).show()
+                // --- CAMBIO AQUÍ: Se reemplazó el Toast por la navegación ---
+                navController.navigate(ScreenNavigation.SavedPosts.route)
+                // --- FIN DEL CAMBIO ---
             }
             ActionCard(title = actions[1].first, icon = actions[1].second, modifier = Modifier.weight(1f)) {
                 Toast.makeText(context, "Ir a ${actions[1].first}", Toast.LENGTH_SHORT).show()
@@ -149,7 +153,7 @@ private fun ActionsGrid(navController: NavHostController) {
 }
 
 // El resto de componentes reutilizables (ProfileHeader, ActionCard, SectionHeader, ProfileListItem)
-// se quedan exactamente igual, ya que solo hemos cambiado los datos que les pasamos.
+// se quedan exactamente igual.
 
 @Composable
 private fun ProfileHeader(state: ProfileUiState) {
@@ -159,15 +163,19 @@ private fun ProfileHeader(state: ProfileUiState) {
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Image(
-            painter = rememberAsyncImagePainter(model = state.profileImageUrl),
-            contentDescription = "Foto de perfil",
+        Box(
             modifier = Modifier
                 .size(80.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant),
-            contentScale = ContentScale.Crop
-        )
+                .background(MaterialTheme.colorScheme.surfaceVariant, shape = CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.AccountCircle, // Icono de perfil
+                contentDescription = "Foto de perfil",
+                modifier = Modifier.size(64.dp), // Tamaño del icono dentro del círculo
+                tint = MaterialTheme.colorScheme.onSurfaceVariant // Color del icono
+            )
+        }
         Spacer(Modifier.height(8.dp))
         Text(state.userName, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
         TextButton(onClick = { /* TODO: Navegar al perfil público */ }) {

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/publication/views/NewProduct.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/publication/views/NewProduct.kt
@@ -9,17 +9,21 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState // ✨ --- ¡IMPORT NUEVO! (Para el scroll) --- ✨
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll // ✨ --- ¡IMPORT NUEVO! (Para el scroll) --- ✨
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults // ✨ --- IMPORT NUEVO para ButtonDefaults --- ✨
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -47,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
+import com.swapi.swapiV1.utils.dismissKeyboardOnClick // ✨ --- ¡IMPORT YA EXISTENTE! --- ✨
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -58,10 +63,8 @@ fun NewPublicationView(navController: NavController) {
     var categoria by remember { mutableStateOf("") }
     var expanded by remember { mutableStateOf(false) }
 
-    // --- CAMBIO 2: Estado para la imagen ---
     var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
 
-    // --- CAMBIO 3: Launcher de la galería ---
     val galleryLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri ->
@@ -72,6 +75,11 @@ fun NewPublicationView(navController: NavController) {
     )
 
     val categorias = listOf("Ventas", "Rentas", "Información", "Servicios")
+
+    val scrollState = rememberScrollState()
+
+    // ✨ Definimos tu color de marca aquí para reusarlo
+    val swapiBrandColor = Color(0xFF4A8BFF)
 
     Scaffold(
         topBar = {
@@ -101,20 +109,22 @@ fun NewPublicationView(navController: NavController) {
                     )
                 )
                 .padding(padding)
+                .dismissKeyboardOnClick()
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(24.dp),
+                    .padding(24.dp)
+                    .verticalScroll(scrollState),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                // ... (TextFields de Título, Descripción, Precio y Dropdown se quedan igual)
                 OutlinedTextField(
                     value = titulo,
                     onValueChange = { titulo = it },
                     label = { Text("Título") },
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(12.dp),
+                    singleLine = true
                 )
 
                 OutlinedTextField(
@@ -135,7 +145,8 @@ fun NewPublicationView(navController: NavController) {
                     label = { Text("Precio") },
                     prefix = { Text("$") },
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(12.dp),
+                    singleLine = true
                 )
 
                 ExposedDropdownMenuBox(
@@ -171,17 +182,15 @@ fun NewPublicationView(navController: NavController) {
                     }
                 }
 
-                // --- CAMBIO 4: Lógica del Box de imagen ---
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(180.dp)
-                        .clip(RoundedCornerShape(16.dp)) // <-- Clip aplicado primero
+                        .clip(RoundedCornerShape(16.dp))
                         .background(
                             MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
                         )
                         .clickable {
-                            // Abre la galería
                             galleryLauncher.launch(
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
                             )
@@ -189,7 +198,6 @@ fun NewPublicationView(navController: NavController) {
                     contentAlignment = Alignment.Center
                 ) {
                     if (selectedImageUri == null) {
-                        // Muestra el ícono si no hay imagen
                         Icon(
                             Icons.Default.CameraAlt,
                             contentDescription = "Subir imagen",
@@ -197,7 +205,6 @@ fun NewPublicationView(navController: NavController) {
                             modifier = Modifier.size(48.dp)
                         )
                     } else {
-                        // Muestra la imagen seleccionada
                         AsyncImage(
                             model = selectedImageUri,
                             contentDescription = "Imagen seleccionada",
@@ -207,16 +214,22 @@ fun NewPublicationView(navController: NavController) {
                     }
                 }
 
-                // 🚀 Botón publicar
+                // 🚀 Botón publicar - ¡AHORA AZUL SWAPI!
                 Button(
                     onClick = { /* acción futura */ },
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(55.dp),
-                    shape = RoundedCornerShape(14.dp)
+                    shape = RoundedCornerShape(14.dp),
+                    colors = ButtonDefaults.buttonColors( // ✨ Aplicamos los colores
+                        containerColor = swapiBrandColor, // Tu color azul
+                        contentColor = Color.White        // Texto blanco
+                    )
                 ) {
                     Text("Publicar", fontSize = 18.sp)
                 }
+
+                Spacer(modifier = Modifier.height(24.dp))
             }
         }
     }

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/sales/views/SalesProductCard.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/sales/views/SalesProductCard.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -37,12 +36,13 @@ fun SaleProductCard(
     format.maximumFractionDigits = 0
 
     var isPressed by remember { mutableStateOf(false) }
-
     val scale by animateFloatAsState(
         targetValue = if (isPressed) 0.97f else 1f,
         animationSpec = tween(180),
         label = "cardScale"
     )
+
+    val swapiBrandColor = Color(0xFF4A8BFF)
 
     Card(
         modifier = Modifier
@@ -51,32 +51,34 @@ fun SaleProductCard(
                 scaleX = scale
                 scaleY = scale
             }
-            .shadow(
-                elevation = 6.dp,
-                shape = RoundedCornerShape(20.dp),
-                clip = false
-            )
-            .clip(RoundedCornerShape(20.dp))
+            .clip(RoundedCornerShape(24.dp))
             .clickable {
                 isPressed = true
                 onClick()
             },
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.98f)
+            containerColor = Color.Transparent
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(20.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                        )
+                    )
+                )
         ) {
-            // Imagen del producto con overlay sutil
+            // Imagen superior (sin cambios)
             Box(
                 modifier = Modifier
-                    .size(80.dp)
-                    .clip(RoundedCornerShape(14.dp))
+                    .fillMaxWidth()
+                    .height(160.dp)
+                    .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
             ) {
                 AsyncImage(
                     model = listing.imageUrl,
@@ -89,21 +91,18 @@ fun SaleProductCard(
                         .fillMaxSize()
                         .background(
                             Brush.verticalGradient(
-                                listOf(
-                                    Color.Transparent,
-                                    Color.Black.copy(alpha = 0.05f)
-                                )
+                                0f to Color.Transparent,
+                                1f to Color.Black.copy(alpha = 0.1f)
                             )
                         )
                 )
             }
 
-            Spacer(modifier = Modifier.width(20.dp))
-
-            // Info del producto
+            // Contenido textual (sin cambios)
             Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(6.dp)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 16.dp)
             ) {
                 Text(
                     text = listing.category.uppercase(),
@@ -111,44 +110,54 @@ fun SaleProductCard(
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Medium
                     ),
-                    color = MaterialTheme.colorScheme.primary
+                    color = swapiBrandColor
                 )
+
+                Spacer(Modifier.height(4.dp))
 
                 Text(
                     text = listing.title,
                     style = MaterialTheme.typography.titleMedium.copy(
                         fontWeight = FontWeight.SemiBold,
-                        fontSize = 16.sp
+                        fontSize = 17.sp
                     ),
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
 
-                Text(
-                    text = format.format(listing.price),
-                    style = MaterialTheme.typography.titleLarge.copy(
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 18.sp
-                    ),
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-            }
+                Spacer(Modifier.height(10.dp))
 
-            // Botón de navegación más limpio y elegante
-            Box(
-                modifier = Modifier
-                    .size(36.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    Icons.Filled.ArrowForward,
-                    contentDescription = "Ver detalles",
-                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
-                    modifier = Modifier.size(18.dp)
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = format.format(listing.price),
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 19.sp
+                        ),
+                        color = swapiBrandColor
+                    )
+
+                    // Botón (Este código ya no tiene sombra, así que está listo)
+                    Box(
+                        modifier = Modifier
+                            .size(38.dp)
+                            .clip(CircleShape)
+                            .clickable { onClick() },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            Icons.Filled.ArrowForward,
+                            contentDescription = "Ver detalles",
+                            tint = swapiBrandColor,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
             }
         }
     }

--- a/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/utils/KeyboardUtils.kt
+++ b/Swapi-APP-ANDROID/app/src/main/java/com/swapi/swapiV1/utils/KeyboardUtils.kt
@@ -1,0 +1,36 @@
+package com.swapi.swapiV1.utils // O donde quieras ponerlo
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+
+/**
+ * Este Modifier personalizado cierra el teclado cuando se hace clic
+ * en el Composable que lo tiene.
+ * * Se usa "composed" para obtener acceso a los controladores (Keyboard/Focus).
+ */
+fun Modifier.dismissKeyboardOnClick(): Modifier = composed {
+    // 1. Obtenemos el controlador del teclado
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    // 2. Obtenemos el manejador de "foco" (quién está seleccionado)
+    val focusManager = LocalFocusManager.current
+
+    this.clickable(
+        // 3. Hacemos que sea clickeable, pero...
+
+        // ...sin "ripple" (el efecto visual de onda)
+        indication = null,
+
+        // ...sin estado de interacción (para que no parezca un botón)
+        interactionSource = remember { MutableInteractionSource() }
+    ) {
+        // 4. Cuando se hace clic en el área de este Modifier:
+        keyboardController?.hide() // (A) Escondemos el teclado
+        focusManager.clearFocus()  // (B) Le quitamos el foco al TextField
+    }
+}


### PR DESCRIPTION
Implements the SavedPostsView feature, accessible from the Profile screen and wired into the TabBarNavigationView.

Fixes a critical crash on the Login screen when clicking 'Create Account'. Now correctly redirects to the demo verification flow.

Refactors UI/UX:
- Applies swapiBrandColor globally to buttons, FABs, and icons.
- Implements 'dismiss keyboard on tap outside' for text fields.
- Improves Login UI and updates SaleProductCard.